### PR TITLE
Readme and logging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Installation
 
 After checking this repo out one installs the corresponding python package as follows
 
-``CorporaCreator kdavis$ python setup.py install``
+``CorporaCreator$ python3 setup.py install``
 
 
 Usage
@@ -19,7 +19,7 @@ Usage
 
 Given a ``clips.tsv`` file dumped from the Common Voice database one creates a corpora in the directory ``corpora`` as follows
 
-``CorporaCreator kdavis$ create-corpora -d corpora -f clips.tsv``
+``CorporaCreator$ create-corpora -d corpora -f clips.tsv``
 
 This will create the corpora in the directory ``corpora`` from the ``clips.tsv`` file.
 
@@ -29,11 +29,11 @@ The split of ``valid.tsv`` into ``train.tsv``, ``dev.tsv``, and ``test.tsv`` is 
 
 By default no sentence occurs more than once in ``train.tsv``, ``dev.tsv``, and ``test.tsv``. However, one can relax this constraint using the ``-s`` command line parameter. The value of ``-s`` is the number of repeats allows for a sentence. So, for example, if one wanted to allow for a setence to occur 3 times in a corpus, then one could use
 
-``CorporaCreator kdavis$ create-corpora -d corpora -f clips.tsv -s 3``
+``CorporaCreator$ create-corpora -d corpora -f clips.tsv -s 3``
 
 With or without the use of the ``-s`` command line parameter the result of running ``create-corpora`` will be a directory containing the following files::
 
-    CorporaCreator kdavis$ tree corpora
+    CorporaCreator$ tree corpora
     corpora
     ├── br
     │   ├── dev.tsv

--- a/src/corporacreator/corpora.py
+++ b/src/corporacreator/corpora.py
@@ -7,8 +7,9 @@ import pandas as pd
 from corporacreator import Corpus
 from corporacreator.preprocessors import common
 
-
 _logger = logging.getLogger(__name__)
+_logger.setLevel(logging.DEBUG)
+_logger.addHandler(logging.FileHandler('corpora.log'))
 
 
 def common_wrapper(sentence, up_votes, down_votes):

--- a/src/corporacreator/corpora.py
+++ b/src/corporacreator/corpora.py
@@ -8,8 +8,6 @@ from corporacreator import Corpus
 from corporacreator.preprocessors import common
 
 _logger = logging.getLogger(__name__)
-_logger.setLevel(logging.DEBUG)
-_logger.addHandler(logging.FileHandler('corpora.log'))
 
 
 def common_wrapper(sentence, up_votes, down_votes):

--- a/src/corporacreator/corpus.py
+++ b/src/corporacreator/corpus.py
@@ -7,8 +7,6 @@ import corporacreator.preprocessors as preprocessors
 import pandas as pd
 
 _logger = logging.getLogger(__name__)
-_logger.setLevel(logging.DEBUG)
-_logger.addHandler(logging.FileHandler('corpus.log'))
 
 
 class Corpus:

--- a/src/corporacreator/corpus.py
+++ b/src/corporacreator/corpus.py
@@ -6,8 +6,9 @@ import corporacreator.preprocessors as preprocessors
 
 import pandas as pd
 
-
 _logger = logging.getLogger(__name__)
+_logger.setLevel(logging.DEBUG)
+_logger.addHandler(logging.FileHandler('corpus.log'))
 
 
 class Corpus:

--- a/src/corporacreator/preprocessors/et.py
+++ b/src/corporacreator/preprocessors/et.py
@@ -7,4 +7,4 @@ def et(client_id, sentence):
       (str): Cleaned up sentence. Returning None or a `str` of whitespace flags the sentence as invalid.
     """
     # TODO: Clean up en data
-return sentence
+    return sentence

--- a/src/corporacreator/tool.py
+++ b/src/corporacreator/tool.py
@@ -7,8 +7,6 @@ from corporacreator import setup_logging
 
 
 _logger = logging.getLogger(__name__)
-_logger.setLevel(logging.DEBUG)
-_logger.addHandler(logging.FileHandler('tool.log'))
 
 def main(args):
     """Main entry point allowing external calls

--- a/src/corporacreator/tool.py
+++ b/src/corporacreator/tool.py
@@ -7,7 +7,8 @@ from corporacreator import setup_logging
 
 
 _logger = logging.getLogger(__name__)
-
+_logger.setLevel(logging.DEBUG)
+_logger.addHandler(logging.FileHandler('tool.log'))
 
 def main(args):
     """Main entry point allowing external calls


### PR DESCRIPTION
Small changes to README (python must be python3, and `CorporaCreator kdavis$` is a little confusing with the whitespace).

Also, added to the `logger` to be more verbose at the terminal and print to log files.