### PR TITLE
Debug log when preprocessor for a locale is missing (instead of crashing)

### DIFF
--- a/src/corporacreator/corpus.py
+++ b/src/corporacreator/corpus.py
@@ -45,9 +45,12 @@ class Corpus:
 
     def _preprocessor_wrapper(self, client_id, sentence, up_votes, down_votes):
         preprocessor = getattr(
-            preprocessors, self.locale.replace("-", "")
+            preprocessors, self.locale.replace("-", ""), None
         )  # Get locale specific preprocessor
-        sentence = preprocessor(client_id, sentence)
+        if preprocessor is None:
+            _logger.debug("No preprocessor found for %s." % self.locale)
+        else:
+            sentence = preprocessor(client_id, sentence)
         if None == sentence or not sentence.strip():
             up_votes = 0
             down_votes = 2


### PR DESCRIPTION
I thought that might be a nicer experience for when new locales are added.