### PR TITLE
removed unnecessary quotationmarks from de-lang sentences

### DIFF
--- a/src/corporacreator/preprocessors/de.py
+++ b/src/corporacreator/preprocessors/de.py
@@ -1,12 +1,12 @@
 import re
 QUOTE_PATTERN = re.compile(r'^\"{3}(.*)\"{2}(.*)\"{1}$')
 QUOTE_PATTERN_2 = re.compile(r'^\"{1}(.*)\"{2}(.*)\"{2}(.*)\"{1}$')
-QUOTE_PATTERN_3 = re.compile(r'^\"{1}(.*)\"{1}')
+QUOTE_PATTERN_3 = re.compile(r'^\"{1}(.*)\"{1}$')
     
 def _change_multi_quotes(sentence):
     """Changes all quotes from patterns like 
-    [\"""content""content"] to [content content] or
-    ["content""content""content"] to [content "content" content] or
+    [\"""content""content"] to ["content"content] or
+    ["content""content""content"] to [content"content"content] or
     ["content" to content]
     
     Args:
@@ -21,7 +21,7 @@ def _change_multi_quotes(sentence):
     matches3 = QUOTE_PATTERN_3.match(sentence) # patter: \"content\"
     
     if matches != None and matches.lastindex == 2:
-        return "{}{}".format(matches.group(1), matches.group(2))
+        return "\"{}\"{}".format(matches.group(1), matches.group(2))
     elif matches2 != None and matches2.lastindex == 3:
         return "{}\"{}\"{}".format(matches2.group(1), matches2.group(2), matches2.group(3))
     elif matches3 != None and matches3.lastindex == 1:

--- a/src/corporacreator/preprocessors/de.py
+++ b/src/corporacreator/preprocessors/de.py
@@ -3,11 +3,11 @@ QUOTE_PATTERN = re.compile(r'^\"{3}(.*)\"{2}(.*)\"{1}$')
 QUOTE_PATTERN_2 = re.compile(r'^\"{1}(.*)\"{2}(.*)\"{2}(.*)\"{1}$')
 QUOTE_PATTERN_3 = re.compile(r'^\"{1}(.*)\"{1}')
     
-def _remove_multi_quotes(sentence):
-    """Removes all quotes from patterns like 
-    \"""content""content" or
-    "content""content""content" or
-    "content"
+def _change_multi_quotes(sentence):
+    """Changes all quotes from patterns like 
+    [\"""content""content"] to [content content] or
+    ["content""content""content"] to [content "content" content] or
+    ["content" to content]
     
     Args:
       sentence (str): Sentence to be cleaned up.
@@ -23,7 +23,7 @@ def _remove_multi_quotes(sentence):
     if matches != None and matches.lastindex == 2:
         return "{}{}".format(matches.group(1), matches.group(2))
     elif matches2 != None and matches2.lastindex == 3:
-        return "{}{}{}".format(matches2.group(1), matches2.group(2), matches2.group(3))
+        return "{}\"{}\"{}".format(matches2.group(1), matches2.group(2), matches2.group(3))
     elif matches3 != None and matches3.lastindex == 1:
         return "{}".format(matches3.group(1))
     
@@ -40,7 +40,7 @@ def de(client_id, sentence):
     Returns:
       (str): Cleaned up sentence. Returning None or a `str` of whitespace flags the sentence as invalid.
     """
-    sentence = _remove_multi_quotes(sentence)
+    sentence = _change_multi_quotes(sentence)
 
     # TODO: Clean up de data
     return sentence

--- a/src/corporacreator/preprocessors/de.py
+++ b/src/corporacreator/preprocessors/de.py
@@ -1,3 +1,35 @@
+import re
+QUOTE_PATTERN = re.compile(r'^\"{3}(.*)\"{2}(.*)\"{1}$')
+QUOTE_PATTERN_2 = re.compile(r'^\"{1}(.*)\"{2}(.*)\"{2}(.*)\"{1}$')
+QUOTE_PATTERN_3 = re.compile(r'^\"{1}(.*)\"{1}')
+    
+def _remove_multi_quotes(sentence):
+    """Removes all quotes from patterns like 
+    \"""content""content" or
+    "content""content""content" or
+    "content"
+    
+    Args:
+      sentence (str): Sentence to be cleaned up.
+      
+    Returns:
+      (str): Cleaned up sentence. Returns the sentence 'as-is', if matching
+      did not work as expected
+    """
+    matches = QUOTE_PATTERN.match(sentence) # pattern: \"\"\"content\"\"content\"
+    matches2 = QUOTE_PATTERN_2.match(sentence) # pattern: \"content\"\"content\"\"content\"
+    matches3 = QUOTE_PATTERN_3.match(sentence) # patter: \"content\"
+    
+    if matches != None and matches.lastindex == 2:
+        return "{}{}".format(matches.group(1), matches.group(2))
+    elif matches2 != None and matches2.lastindex == 3:
+        return "{}{}{}".format(matches2.group(1), matches2.group(2), matches2.group(3))
+    elif matches3 != None and matches3.lastindex == 1:
+        return "{}".format(matches3.group(1))
+    
+    return sentence
+
+
 def de(client_id, sentence):
     """Cleans up the passed sentence, removing or reformatting invalid data.
 
@@ -8,5 +40,7 @@ def de(client_id, sentence):
     Returns:
       (str): Cleaned up sentence. Returning None or a `str` of whitespace flags the sentence as invalid.
     """
+    sentence = _remove_multi_quotes(sentence)
+
     # TODO: Clean up de data
     return sentence


### PR DESCRIPTION
Noticed multiple strange cases of sentences containing a lot of quotation marks in reoccurring patters in german language corpus.

Patterns found:

- """content""content."
- "content""content""content."
- "content."

Examples

- """Beim Wrestling ist alles nur Show"", behauptet Willi."
- "Das Prinzip heißt ""teile und herrsche""."
- "Probier's mal mit Gemütlichkeit!"

Only checked the french corpus as well, the problem did not seem to occur in it. So applied the fix in the de.py preprocessor. (Although I did not check any other language corpus, so your mileage may vary.)