### PR TITLE
common.py --- collapse whitespace for all langs

### DIFF
--- a/src/corporacreator/preprocessors/common.py
+++ b/src/corporacreator/preprocessors/common.py
@@ -75,5 +75,7 @@ def common(sentence):
     sentence = _strip_tags(sentence)
     # Remove non-printable characters
     sentence = _strip_string(sentence)
+    # collapse all whitespace and replace with single space
+    sentence = (' ').join(sentence.split())
     # TODO: Clean up data in a language independent manner
     return sentence


### PR DESCRIPTION
this collapses multiple spaces and tabs into one, single whitespace.

this is language independent