### PR TITLE
kyrgyz mis-typed "oe"

### DIFF
--- a/src/corporacreator/preprocessors/ky.py
+++ b/src/corporacreator/preprocessors/ky.py
@@ -9,5 +9,6 @@ def ky(client_id, sentence):
       (str): Cleaned up sentence. Returning None or a `str` of whitespace flags the sentence as invalid.
     """
     sentence = sentence.replace("•", "")
+    sentence = sentence.replace("ѳ", "ө")
     # TODO: ⅛, ИНН, КСДП, other abbreviations
     return sentence


### PR DESCRIPTION
Old, type has been mixed up with similar modern letter.

Old Fita: https://en.wikipedia.org/wiki/Fita

Modern OE: https://en.wikipedia.org/wiki/Oe_(Cyrillic)