### PR TITLE
Change ticks --> apostrophes

### DIFF
--- a/src/corporacreator/preprocessors/en.py
+++ b/src/corporacreator/preprocessors/en.py
@@ -8,5 +8,8 @@ def en(client_id, sentence):
     Returns:
       (str): Cleaned up sentence. Returning None or a `str` of whitespace flags the sentence as invalid.
     """
-    # TODO: Clean up en data
+    ## collapse all apostrophe-like marks
+    ## e.g. common_voice_en_18441344.mp3	‘I’m not a serpent!’ --> 'I'm not a serpent!'
+    sentence = sentence.replace("’","'") # right-ticks --> apostrophes
+    sentence = sentence.replace("‘","'") # left-ticks --> apostrophes
     return sentence


### PR DESCRIPTION
There are a lot of tick marks that occur in English Common Voice that should be apostrophes

This is part of a larger problem which involves quotation marks / double quotes