### PR TITLE
1563-v1.5.0 upgrade to Polars

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,22 @@
 Changelog
 =========
 
+Version 1.5.0 (2026-03-25)
+===========================
+
+- **Polars rewrite** -- replaced ``pandas`` + ``swifter`` with ``polars>=1.0``
+- Drop-in replacement: CLI interface, TSV output, and split algorithm unchanged
+- Vectorized common preprocessing pipeline
+  (URL decode, HTML strip, unicode category filter, whitespace normalization)
+- Binary search for train/dev/test split sizes -- O(log N) vs O(N)
+- Speaker-based split via O(n) join instead of O(n²) per-speaker filtering
+- Fixed multi-locale processing bug (``del df`` inside loop)
+- Fixed test-split safety cap (was ``train_size``, now correctly ``test_size``)
+- Added Polars DataFrames based test suite
+
+  *PR:* `#134 <https://github.com/common-voice/CorporaCreator/pull/134>`_
+
+
 Version 1.4.2 (2026-03-23)
 ===========================
 

--- a/README.rst
+++ b/README.rst
@@ -10,14 +10,17 @@ This is a command line tool to create Common Voice corpora.
 Version Information
 ===================
 
-**Current Version: 1.4.2** (Python 3.12+ required)
+**Current Version: 1.5.0** (Python 3.12+ required)
 
-Changes since 1.4.0:
+Changes since 1.4.x:
 
-- RAM/CPU optimizations for large datasets (category dtypes, O(n) speaker partitioning)
+- **Polars rewrite** — replaced pandas + swifter with Polars for significantly lower RAM usage and faster processing
+- Vectorized common preprocessing pipeline (URL decode, HTML strip, unicode filter, whitespace normalization)
+- Binary search for train/dev/test split sizes — O(log N) vs O(N) linear scan
+- Speaker-based split via O(n) join instead of O(n²) per-speaker filtering
+- Fixed multi-locale processing bug
 - DEBUG-level resource/memory monitoring (``-vv``) for diagnosing OOM in containers
 - Reworked log formatting with ``CC-PY`` tag for bundler integration
-- Explicit ``__all__`` re-exports per PEP 484
 
 See ``CHANGELOG.rst`` for full history.
 
@@ -35,8 +38,7 @@ Requirements
 ============
 
 - **Python 3.12 or higher**
-- pandas >= 2.0, < 3.0
-- swifter >= 1.0
+- polars >= 1.0
 
 
 Installation
@@ -375,6 +377,14 @@ Run the test suite::
 
 Migration Notes
 ===============
+
+From v1.4.x to v1.5.0
+----------------------
+
+- **pandas + swifter replaced by Polars** — ``pip install`` will pull ``polars>=1.0`` instead
+- Drop-in replacement: CLI interface, TSV output format, and split algorithm are unchanged
+- Significantly lower peak memory usage on large datasets
+- No changes to preprocessor plugin interface (``cy.py``, ``de.py``, ``ky.py`` work as before)
 
 From v1.3.0 to v1.4.x
 ---------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "CorporaCreator"
-version = "1.4.2"
+version = "1.5.0"
 description = "Command line tool to create Common Voice corpora."
 readme = "README.rst"
 requires-python = ">=3.12"
@@ -22,7 +22,7 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 
-dependencies = ["pandas>=2.0,<3.0", "swifter>=1.0"]
+dependencies = ["polars>=1.0"]
 
 [project.optional-dependencies]
 testing = ["pytest>=7.0", "pytest-cov>=4.0"]

--- a/src/corporacreator/corpora.py
+++ b/src/corporacreator/corpora.py
@@ -1,25 +1,61 @@
 import argparse
-import csv
-import gc
+import html
 import logging
 import os
+import re
+from urllib.parse import unquote
 
-import pandas as pd  # type: ignore
-import swifter  # type: ignore # noqa: F401 -- side-effect import, patches pandas with .swifter accessor
+import polars as pl
 
 from corporacreator import Corpus
-from corporacreator.preprocessors import common
 from corporacreator.resources import log_resources
 
 _logger = logging.getLogger(__name__)
 
+# Compiled regex for HTML tag stripping (used in _clean_sentence)
+_RE_HTML_TAGS = re.compile(r"<[^>]+>")
 
-def common_wrapper(sentence, up_votes, down_votes):
-    is_valid, sentence = common(str(sentence))
-    if is_valid is False:
-        up_votes = 0
-        down_votes = 2
-    return pd.Series([sentence, up_votes, down_votes])
+
+def _clean_sentence(sentence: str) -> str:
+    """Clean a single sentence: URL decode, strip HTML, strip disallowed unicode.
+
+    This is called via map_elements for the steps that require Python-level
+    processing. Whitespace normalization and validity checks are done
+    vectorized in Polars afterward.
+    """
+    sentence = str(sentence)
+    # URL decode
+    if "%" in sentence:
+        sentence = unquote(sentence)
+    # Strip HTML tags via regex
+    sentence = _RE_HTML_TAGS.sub("", sentence)
+    # Convert HTML entities (&amp; -> &, etc.)
+    if "&" in sentence:
+        sentence = html.unescape(sentence)
+    return sentence
+
+
+# Columns expected in clips.tsv (used for column pushdown on read)
+COLUMNS = [
+    "client_id",
+    "path",
+    "sentence_id",
+    "sentence",
+    "sentence_domain",
+    "up_votes",
+    "down_votes",
+    "age",
+    "gender",
+    "accents",
+    "variant",
+    "locale",
+    "segment",
+]
+
+SCHEMA_OVERRIDES = {
+    "up_votes": pl.Int32,
+    "down_votes": pl.Int32,
+}
 
 
 class Corpora:
@@ -38,88 +74,93 @@ class Corpora:
         self.corpora = []
 
     def create(self):
-        """Creates a :class:`corporacreator.Corpus` for each locale.
-        """
+        """Creates a :class:`corporacreator.Corpus` for each locale."""
         _logger.info("Creating corpora...")
-        corpora_data = self._parse_tsv()
-        log_resources("before swifter common_wrapper")
-        corpora_data[["sentence", "up_votes", "down_votes"]] = corpora_data[
-            ["sentence", "up_votes", "down_votes"]
-        ].swifter.apply(func=lambda arg: common_wrapper(*arg), axis=1)
-        log_resources("after swifter common_wrapper")
+        df = self._parse_tsv()
+        log_resources("before preprocess_common")
+        df = self._preprocess_common(df)
+        log_resources("after preprocess_common")
+
         if self.args.langs:
-            # check if all languages provided at command line are actually
-            # in the clips.tsv file, if not, throw error
-            if set(self.args.langs).issubset(set(corpora_data.locale.unique())):
-                locales = self.args.langs
-            else:
-                raise argparse.ArgumentTypeError("ERROR: You have requested languages which do not exist in clips.tsv")
+            available = set(df["locale"].unique().to_list())
+            if not set(self.args.langs).issubset(available):
+                raise argparse.ArgumentTypeError(
+                    "ERROR: You have requested languages which do not exist in clips.tsv"
+                )
+            locales = self.args.langs
         else:
-            locales = corpora_data.locale.unique()
+            locales = df["locale"].unique().to_list()
 
         for locale in locales:
             _logger.info("Selecting %s corpus data..." % locale)
-
-            corpus_data = corpora_data.reindex(
-                columns=[
-                    "client_id",
-                    "path",
-                    "sentence_id",
-                    "sentence",
-                    "sentence_domain",
-                    "up_votes",
-                    "down_votes",
-                    "age",
-                    "gender",
-                    "accents",
-                    "variant",
-                    "locale",
-                    "segment",
-                ]
-            )
-
-            corpus_data = corpus_data.loc[lambda df: df.locale == locale]
-
+            locale_df = df.filter(pl.col("locale") == locale)
             _logger.info("Selected %s corpus data." % locale)
+
             _logger.info("Creating %s corpus..." % locale)
-            corpus = Corpus(self.args, locale, corpus_data)
+            corpus = Corpus(self.args, locale, locale_df)
             corpus.create()
             _logger.info("Created %s corpus." % locale)
             self.corpora.append(corpus)
 
-        del corpora_data
-        gc.collect()
-        log_resources("after gc.collect (corpora_data freed)")
+        del df
+
+        log_resources("after all corpora created")
         _logger.info("Created corpora.")
 
-    def _parse_tsv(self):
+    def _parse_tsv(self) -> pl.DataFrame:
         log_resources("before read_csv")
         _logger.info("Parsing tsv file...")
-        corpora_data = pd.read_csv(
-            self.args.tsv_filename,
-            sep="\t",
-            parse_dates=False,
-            engine="python",
-            encoding="utf-8",
-            on_bad_lines="warn",
-            quotechar='"',
-            quoting=csv.QUOTE_NONE,
-            dtype={
-                "locale": "category",
-                "age": "category",
-                "gender": "category",
-                "accents": "category",
-                "variant": "category",
-                "segment": "category",
-                "up_votes": "int32",
-                "down_votes": "int32",
-            },
+        df = (
+            pl.scan_csv(
+                self.args.tsv_filename,
+                separator="\t",
+                encoding="utf8",
+                schema_overrides=SCHEMA_OVERRIDES,
+                ignore_errors=True,
+                quote_char=None,
+            )
+            .select([c for c in COLUMNS])
+            .collect()
         )
-        _logger.info("Parsed %d lines tsv file." % len(corpora_data))
+        _logger.info("Parsed %d lines tsv file." % len(df))
         if _logger.isEnabledFor(logging.DEBUG):
-            mem_mb = corpora_data.memory_usage(deep=True).sum() / 1024 / 1024
-            log_resources("after read_csv", f"{len(corpora_data)} rows, DataFrame={mem_mb:.0f}MB")
-        return corpora_data
+            mem_mb = df.estimated_size("mb")
+            log_resources("after read_csv", "%d rows, DataFrame=%.0fMB" % (len(df), mem_mb))
+        return df
+
+    def _preprocess_common(self, df: pl.DataFrame) -> pl.DataFrame:
+        """Vectorized equivalent of the old swifter common_wrapper apply.
+
+        Pipeline:
+          1. URL decode + HTML strip + entity decode  (map_elements -- Python)
+          2. Strip disallowed unicode categories       (vectorized Polars regex)
+          3. Normalize whitespace                      (vectorized Polars str ops)
+          4. Validity: digits / empty                  (vectorized boolean masks)
+        """
+        s = df["sentence"].cast(pl.String)
+
+        # 1. Python-level cleaning: URL decode, HTML tags, HTML entities
+        s = s.map_elements(_clean_sentence, return_dtype=pl.String)
+
+        # 2. Strip disallowed unicode -- FULLY VECTORIZED via Polars/Rust regex
+        #    Allowed categories (matches v1 _strip_string exactly):
+        #      Letters (L), Numbers (N), Marks (M), Punctuation (P),
+        #      Symbols (S), Space Separators (Zs)
+        s = s.str.replace_all(r"[^\p{L}\p{N}\p{M}\p{P}\p{S}\p{Zs}]", "")
+
+        # 3. Normalize whitespace -- vectorized
+        s = s.str.replace_all(r"\s+", " ").str.strip_chars()
+
+        # 4. Validity masks -- fully vectorized boolean operations
+        has_digit = s.str.contains(r"\d")
+        is_empty = s.str.len_chars().eq(0)
+        is_invalid = has_digit | is_empty
+
+        return df.with_columns([
+            s.alias("sentence"),
+            pl.when(is_invalid).then(0).otherwise(pl.col("up_votes")).alias("up_votes"),
+            pl.when(is_invalid).then(2).otherwise(pl.col("down_votes")).alias("down_votes"),
+        ])
 
     def save(self, directory):
         """Saves this :class:`corporacreator.Corpora` in `directory`.

--- a/src/corporacreator/corpora.py
+++ b/src/corporacreator/corpora.py
@@ -122,11 +122,27 @@ class Corpora:
             .select([c for c in COLUMNS])
             .collect()
         )
+        # Warn about silently skipped rows (Polars ignore_errors has no
+        # built-in warning mode, unlike pandas on_bad_lines="warn")
+        file_lines = self._count_file_lines(self.args.tsv_filename) - 1  # minus header
+        if len(df) < file_lines:
+            _logger.warning(
+                "Skipped %d malformed rows during TSV parsing", file_lines - len(df)
+            )
         _logger.info("Parsed %d lines tsv file." % len(df))
         if _logger.isEnabledFor(logging.DEBUG):
             mem_mb = df.estimated_size("mb")
             log_resources("after read_csv", "%d rows, DataFrame=%.0fMB" % (len(df), mem_mb))
         return df
+
+    @staticmethod
+    def _count_file_lines(path: str) -> int:
+        """Count newlines in a file using buffered binary read."""
+        count = 0
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                count += chunk.count(b"\n")
+        return count
 
     def _preprocess_common(self, df: pl.DataFrame) -> pl.DataFrame:
         """Vectorized equivalent of the old swifter common_wrapper apply.

--- a/src/corporacreator/corpus.py
+++ b/src/corporacreator/corpus.py
@@ -192,7 +192,7 @@ class Corpus:
             .agg(pl.len().alias("_n_clips"))
         )
         speaker_order = speaker_order.join(
-            speaker_clip_counts, on="client_id"
+            speaker_clip_counts, on="client_id", how="left", maintain_order="left"
         )
 
         # Assign split labels with exact v1 budget logic

--- a/src/corporacreator/corpus.py
+++ b/src/corporacreator/corpus.py
@@ -1,9 +1,7 @@
-import csv
 import logging
 import os
 
-import pandas as pd  # type: ignore
-import swifter  # type: ignore # noqa: F401 -- side-effect import, patches pandas with .swifter accessor
+import polars as pl
 
 import corporacreator
 import corporacreator.preprocessors as preprocessors
@@ -13,17 +11,17 @@ _logger = logging.getLogger(__name__)
 
 
 class Corpus:
-    """Corpus representing a Common Voice datasets for a given locale.
+    """Corpus representing a Common Voice dataset for a given locale.
 
     Args:
       args ([str]): Command line parameters as list of strings
       locale (str): Locale this :class:`corporacreator.Corpus` represents
-      corpus_data (:class:`pandas.DataFrame`): `pandas.DataFrame` Containing the corpus data
+      corpus_data (:class:`polars.DataFrame`): DataFrame containing the corpus data
 
     Attributes:
         args ([str]): Command line parameters as list of strings
         locale (str): Locale of this :class:`corporacreator.Corpus`
-        corpus_data (:class:`pandas.DataFrame`): `pandas.DataFrame` Containing the corpus data
+        corpus_data (:class:`polars.DataFrame`): DataFrame containing the corpus data
     """
 
     def __init__(self, args, locale, corpus_data):
@@ -32,133 +30,231 @@ class Corpus:
         self.corpus_data = corpus_data
 
     def create(self):
-        """Creates a :class:`corporacreator.Corpus` for `self.locale`.
-        """
+        """Creates a :class:`corporacreator.Corpus` for `self.locale`."""
         rows = len(self.corpus_data)
         _logger.debug("Creating %s corpus (%d rows)..." % (self.locale, rows))
         log_resources("before preprocess %s" % self.locale, "%d rows" % rows)
-        self._pre_process_corpus_data()
+        self._preprocess_locale()
         log_resources("after preprocess %s" % self.locale)
-        self._partition_corpus_data()
-        log_resources("after partition %s" % self.locale,
-                      "valid=%d invalid=%d other=%d" % (
-                          len(self.validated), len(self.invalidated), len(self.other)))
+        self._partition()
+        log_resources(
+            "after partition %s" % self.locale,
+            "valid=%d invalid=%d other=%d"
+            % (len(self.validated), len(self.invalidated), len(self.other)),
+        )
         del self.corpus_data
-        self._post_process_valid_data()
-        log_resources("after split %s" % self.locale,
-                      "train=%d dev=%d test=%d" % (
-                          len(self.train), len(self.dev), len(self.test)))
-        _logger.debug("Created %s corpora." % self.locale)
+        self._post_process_validated()
+        log_resources(
+            "after split %s" % self.locale,
+            "train=%d dev=%d test=%d"
+            % (len(self.train), len(self.dev), len(self.test)),
+        )
+        _logger.debug("Created %s corpus." % self.locale)
 
-    def _pre_process_corpus_data(self):
-        self.corpus_data[["sentence", "up_votes", "down_votes"]] = self.corpus_data[
-            ["client_id", "sentence", "up_votes", "down_votes"]
-        ].swifter.apply(func=lambda arg: self._preprocessor_wrapper(*arg), axis=1)
+    # ------------------------------------------------------------------
+    # Locale-specific preprocessing
+    # ------------------------------------------------------------------
 
-    def _preprocessor_default(self, client_id, sentence):
-        return sentence
+    def _preprocess_locale(self):
+        """Apply locale-specific preprocessor -- skipped if none exists."""
+        locale_key = self.locale.replace("-", "")
+        proc = getattr(preprocessors, locale_key, None)
+        if proc is None:
+            return  # no preprocessor for this locale (e.g. ps, en) -- skip
 
-    def _preprocessor_wrapper(self, client_id, sentence, up_votes, down_votes):
-        preprocessor = getattr(
-            preprocessors, self.locale.replace("-", ""), self._preprocessor_default
-        )  # Get locale specific preprocessor
-        sentence = preprocessor(client_id, sentence)
-        if sentence is None or not sentence.strip():
-            up_votes = 0
-            down_votes = 2
-        return pd.Series([sentence, up_votes, down_votes])
+        _logger.debug("Applying %s locale preprocessor..." % self.locale)
 
-    def _partition_corpus_data(self):
+        # Build a struct of the columns the preprocessor needs, then
+        # map_elements to apply the locale-specific function per row.
+        new_sentence = (
+            pl.struct(["client_id", "sentence"])
+            .map_elements(
+                lambda row: proc(row["client_id"], row["sentence"]),
+                return_dtype=pl.String,
+            )
+        )
+
+        is_invalid = new_sentence.is_null() | (
+            new_sentence.str.strip_chars().str.len_chars().eq(0)
+        )
+
+        self.corpus_data = self.corpus_data.with_columns([
+            new_sentence.alias("sentence"),
+            pl.when(is_invalid)
+            .then(0)
+            .otherwise(pl.col("up_votes"))
+            .alias("up_votes"),
+            pl.when(is_invalid)
+            .then(2)
+            .otherwise(pl.col("down_votes"))
+            .alias("down_votes"),
+        ])
+
+    # ------------------------------------------------------------------
+    # Partition
+    # ------------------------------------------------------------------
+
+    def _partition(self):
+        df = self.corpus_data
+        vote_sum = pl.col("up_votes") + pl.col("down_votes")
+
         # If there are < 2 votes, or 2 opposing votes
         # there is not enough information to make a determination
-        self.other = self.corpus_data.loc[
-            lambda df: (df.up_votes + df.down_votes <= 1)
-            | ((df.up_votes == 1) & (df.down_votes == 1)), :
-        ]
-        # If there are 2+ votes, and up_votes > down_votes, clip is valid
-        self.validated = self.corpus_data.loc[
-            lambda df: (df.up_votes + df.down_votes > 1)
-            & (df.up_votes > df.down_votes),
-            :,
-        ]
-        # If there are 2+ votes, and down_votes > up_votes, clip is invalid
-        # If there are 3+ votes, and up_votes == down_votes, opinions
-        # are diverging too much to be relied upon, and clip is invalid
-        self.invalidated = self.corpus_data.loc[
-            lambda df: ((df.up_votes + df.down_votes > 1)
-                & (df.up_votes < df.down_votes))
-            | ((df.up_votes == df.down_votes)
-                & (df.up_votes + df.down_votes > 2)),
-            :,
-        ]
-
-    def _post_process_valid_data(self):
-        # Remove duplicate sentences while maintaining maximal user diversity at the frame's start (TODO: Make addition of user_sentence_count cleaner)
-        speaker_counts = self.validated["client_id"].value_counts()
-        speaker_counts = speaker_counts.to_frame().reset_index()
-        speaker_counts.columns = ["client_id", "user_sentence_count"]
-        self.validated = self.validated.join(
-            speaker_counts.set_index("client_id"), on="client_id"
+        self.other = df.filter(
+            (vote_sum <= 1)
+            | ((pl.col("up_votes") == 1) & (pl.col("down_votes") == 1))
         )
-        self.validated = self.validated.sort_values(["user_sentence_count", "client_id"])
-        validated = self.validated.groupby("sentence").head(self.args.duplicate_sentence_count)
+        # If there are 2+ votes, and up_votes > down_votes, clip is valid
+        self.validated = df.filter(
+            (vote_sum > 1) & (pl.col("up_votes") > pl.col("down_votes"))
+        )
+        # If there are 2+ votes, and down_votes > up_votes, clip is invalid
+        # If there are 3+ votes, and up_votes == down_votes, clip is invalid
+        self.invalidated = df.filter(
+            ((vote_sum > 1) & (pl.col("up_votes") < pl.col("down_votes")))
+            | (
+                (pl.col("up_votes") == pl.col("down_votes"))
+                & (vote_sum > 2)
+            )
+        )
 
-        validated = validated.sort_values(["user_sentence_count", "client_id"], ascending=False)
-        validated = validated.drop(columns="user_sentence_count")
-        self.validated = self.validated.drop(columns="user_sentence_count")
+    # ------------------------------------------------------------------
+    # Validated post-processing: dedup + split
+    # ------------------------------------------------------------------
 
+    def _post_process_validated(self):
+        validated = self.validated
 
-        train = pd.DataFrame(columns=validated.columns)
-        dev = pd.DataFrame(columns=validated.columns)
-        test = pd.DataFrame(columns=validated.columns)
+        if len(validated) == 0:
+            self.train = self.dev = self.test = validated
+            return
 
-        train_size = dev_size = test_size = 0
+        # --- Speaker clip counts ---
+        speaker_counts = (
+            validated
+            .group_by("client_id")
+            .agg(pl.len().alias("user_sentence_count"))
+        )
+        validated = (
+            validated
+            .join(speaker_counts, on="client_id")
+            .sort(["user_sentence_count", "client_id"])
+        )
 
-        if (len(validated) > 0):
-            # Determine train, dev, and test sizes
-            train_size, dev_size, test_size = self._calculate_data_set_sizes(len(validated))
-            # Split into train, dev, and test datasets
-            continous_client_index, uniques = pd.factorize(validated["client_id"])
-            validated["continous_client_index"] = continous_client_index
+        # Store validated with user_sentence_count dropped (matches v1 output)
+        self.validated = validated.drop("user_sentence_count")
 
-            # Pre-partition by speaker once (O(n)) instead of scanning per iteration (O(n²))
-            groups = {k: v for k, v in validated.groupby("continous_client_index", sort=False)}
+        # --- Sentence deduplication ---
+        # Keep first N occurrences per sentence (those with lowest
+        # user_sentence_count = most diverse speakers), matching v1's
+        # groupby("sentence").head(n)
+        deduped = (
+            validated
+            .with_row_index("_row_idx")
+            .with_columns(
+                pl.col("_row_idx")
+                .rank("ordinal")
+                .over("sentence")
+                .alias("_sentence_rank")
+            )
+            .filter(
+                pl.col("_sentence_rank") <= self.args.duplicate_sentence_count
+            )
+            .drop(["_row_idx", "_sentence_rank"])
+        )
 
-            train_parts, dev_parts, test_parts = [], [], []
-            test_count = dev_count = 0
+        # Sort descending (speakers with most clips first = lowest factorize
+        # index in v1) then prepare for split
+        deduped = deduped.sort(
+            ["user_sentence_count", "client_id"], descending=True
+        )
 
-            for i in range(max(continous_client_index), -1, -1):
-                speaker_data = groups[i]
-                n = len(speaker_data)
-                if test_count + n <= test_size:
-                    test_parts.append(speaker_data)
-                    test_count += n
-                elif dev_count + n <= dev_size:
-                    dev_parts.append(speaker_data)
-                    dev_count += n
-                else:
-                    train_parts.append(speaker_data)
+        train_size, dev_size, test_size = self._calculate_split_sizes(
+            len(deduped)
+        )
 
-            train = pd.concat(train_parts, sort=False) if train_parts else pd.DataFrame(columns=validated.columns)
-            dev   = pd.concat(dev_parts, sort=False)   if dev_parts   else pd.DataFrame(columns=validated.columns)
-            test  = pd.concat(test_parts, sort=False)   if test_parts  else pd.DataFrame(columns=validated.columns)
+        # --- Speaker split (exact v1 logic, O(n) via speaker-level loop) ---
+        # Get unique speakers in order of first appearance (most clips first
+        # in descending-sorted deduped), then reverse to match v1's
+        # range(max(continous_client_index), -1, -1) which processes
+        # speakers with fewest clips first.
+        speaker_order = (
+            deduped
+            .select("client_id")
+            .unique(maintain_order=True)
+            .reverse()
+        )
 
-        self.train = train.drop(columns="continous_client_index", errors="ignore")
-        self.dev = dev.drop(columns="continous_client_index", errors="ignore")
-        self.test = test[:train_size].drop(columns="continous_client_index", errors="ignore")
+        # Get clip count per speaker
+        speaker_clip_counts = (
+            deduped
+            .group_by("client_id")
+            .agg(pl.len().alias("_n_clips"))
+        )
+        speaker_order = speaker_order.join(
+            speaker_clip_counts, on="client_id"
+        )
 
-    def _calculate_data_set_sizes(self, total_size):
-        # Find maximum size for the training data set in accord with sample theory
-        train_size = total_size
-        dev_size = 0
-        test_size = 0
-        for train_size in range(total_size, 0, -1):
-            calculated_sample_size = int(corporacreator.sample_size(train_size))
-            if 2 * calculated_sample_size + train_size <= total_size:
-                dev_size = calculated_sample_size
-                test_size = calculated_sample_size
-                break
-        return train_size, dev_size, test_size
+        # Assign split labels with exact v1 budget logic
+        test_used = dev_used = 0
+        labels = []
+        for n in speaker_order["_n_clips"].to_list():
+            if test_used + n <= test_size:
+                labels.append("test")
+                test_used += n
+            elif dev_used + n <= dev_size:
+                labels.append("dev")
+                dev_used += n
+            else:
+                labels.append("train")
+
+        speaker_order = speaker_order.with_columns(
+            pl.Series("_split", labels)
+        )
+
+        # Join split labels back -- single O(n) join, no concat loop
+        result = deduped.join(
+            speaker_order.select(["client_id", "_split"]),
+            on="client_id",
+        ).drop("user_sentence_count")
+
+        self.train = (
+            result.filter(pl.col("_split") == "train").drop("_split")
+        )
+        self.dev = (
+            result.filter(pl.col("_split") == "dev").drop("_split")
+        )
+        self.test = (
+            result.filter(pl.col("_split") == "test")
+            .drop("_split")
+            .head(test_size)
+        )
+
+    def _calculate_split_sizes(self, total_size):
+        """Binary search for max train_size where
+        2 * sample_size(train_size) + train_size <= total_size.
+
+        f(t) = 2*sample_size(t) + t is strictly monotonically increasing,
+        so binary search applies. O(log N) = ~23 iterations for 5M clips
+        vs ~33K iterations in v1.
+        """
+        if total_size == 0:
+            return 0, 0, 0
+
+        lo, hi = 0, total_size
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if 2 * int(corporacreator.sample_size(mid)) + mid <= total_size:
+                lo = mid
+            else:
+                hi = mid - 1
+        train_size = lo
+        sample = int(corporacreator.sample_size(train_size))
+        return train_size, sample, sample
+
+    # ------------------------------------------------------------------
+    # Save
+    # ------------------------------------------------------------------
 
     def save(self, directory):
         """Saves this :class:`corporacreator.Corpus` in `directory`.
@@ -171,15 +267,12 @@ class Corpus:
             os.mkdir(directory)
         datasets = ["other", "invalidated", "validated", "train", "dev", "test"]
 
-        _logger.debug("Saving %s corpora..." % self.locale)
+        _logger.debug("Saving %s corpus..." % self.locale)
         for dataset in datasets:
             self._save(directory, dataset)
-        _logger.debug("Saved %s corpora." % self.locale)
+        _logger.debug("Saved %s corpus." % self.locale)
 
     def _save(self, directory, dataset):
         path = os.path.join(directory, dataset + ".tsv")
-
-        dataframe = getattr(self, dataset)
-        dataframe.to_csv(
-            path, sep="\t", header=True, index=False, encoding="utf-8", escapechar='\\', quoting=csv.QUOTE_NONE
-        )
+        df: pl.DataFrame = getattr(self, dataset)
+        df.write_csv(path, separator="\t", quote_style="never")

--- a/src/corporacreator/preprocessors/common.py
+++ b/src/corporacreator/preprocessors/common.py
@@ -5,7 +5,7 @@ from urllib.parse import unquote
 from html.parser import HTMLParser
 
 
-RE_DIGITS = re.compile('\d')
+RE_DIGITS = re.compile(r'\d')
 
 def _has_digit(sentence):
     return RE_DIGITS.search(sentence)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,63 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-"""
-    Dummy conftest.py for corporacreator.
+"""Shared fixtures for CorporaCreator v1.5 tests."""
 
-    If you don't know what this is for, just leave it empty.
-    Read more about conftest.py under:
-    https://pytest.org/latest/plugins.html
-"""
+import os
+import types
 
-# import pytest
+import pytest
+import polars as pl
+
+
+@pytest.fixture
+def tmp_tsv(tmp_path):
+    """Create a minimal clips.tsv file and return its path."""
+
+    def _make(rows, filename="clips.tsv"):
+        header = (
+            "client_id\tpath\tsentence_id\tsentence\tsentence_domain\t"
+            "up_votes\tdown_votes\tage\tgender\taccents\tvariant\tlocale\tsegment"
+        )
+        lines = [header] + ["\t".join(str(c) for c in row) for row in rows]
+        path = tmp_path / filename
+        path.write_text("\n".join(lines), encoding="utf-8")
+        return str(path)
+
+    return _make
+
+
+@pytest.fixture
+def make_args(tmp_path):
+    """Create a mock args namespace matching corporacreator.parse_args output."""
+
+    def _make(tsv_path, langs=None, duplicate_sentence_count=1):
+        return types.SimpleNamespace(
+            tsv_filename=tsv_path,
+            directory=str(tmp_path / "output"),
+            langs=langs,
+            duplicate_sentence_count=duplicate_sentence_count,
+            loglevel=None,
+        )
+
+    return _make
+
+
+# -- Reusable row data --
+
+def make_row(
+    client_id="c1",
+    path="c1/audio.mp3",
+    sentence_id="s1",
+    sentence="hello world",
+    sentence_domain="",
+    up_votes=2,
+    down_votes=0,
+    age="",
+    gender="",
+    accents="",
+    variant="",
+    locale="en",
+    segment="",
+):
+    return (
+        client_id, path, sentence_id, sentence, sentence_domain,
+        up_votes, down_votes, age, gender, accents, variant, locale, segment,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,8 @@
 """Shared fixtures for CorporaCreator v1.5 tests."""
 
-import os
 import types
 
 import pytest
-import polars as pl
 
 
 @pytest.fixture

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -1,8 +1,27 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+"""Tests for corporacreator.argparse (unchanged from v1)."""
 
 import pytest
+from corporacreator import parse_args
 
-__license__ = "mpl"
-__author__ = "kdavis-mozilla"
-__copyright__ = "kdavis-mozilla"
+
+class TestParseArgs:
+    def test_required_args(self):
+        args = parse_args(["-f", "input.tsv", "-d", "output/"])
+        assert args.tsv_filename == "input.tsv"
+        assert args.directory == "output/"
+
+    def test_default_duplicate_count(self):
+        args = parse_args(["-f", "input.tsv", "-d", "output/"])
+        assert args.duplicate_sentence_count == 1
+
+    def test_custom_duplicate_count(self):
+        args = parse_args(["-f", "input.tsv", "-d", "output/", "-s", "3"])
+        assert args.duplicate_sentence_count == 3
+
+    def test_langs_option(self):
+        args = parse_args(["-f", "input.tsv", "-d", "output/", "-l", "en", "de"])
+        assert args.langs == ["en", "de"]
+
+    def test_no_langs_default(self):
+        args = parse_args(["-f", "input.tsv", "-d", "output/"])
+        assert args.langs is None

--- a/tests/test_corpora.py
+++ b/tests/test_corpora.py
@@ -1,8 +1,135 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+"""Tests for corporacreator.corpora (v1.5 Polars rewrite)."""
 
+import polars as pl
 import pytest
 
-__license__ = "mpl"
-__author__ = "kdavis-mozilla"
-__copyright__ = "kdavis-mozilla"
+from corporacreator import Corpora
+from corporacreator.corpora import _clean_sentence
+from conftest import make_row
+
+
+class TestCleanSentence:
+    """Unit tests for _clean_sentence helper."""
+
+    def test_plain_text_unchanged(self):
+        assert _clean_sentence("hello world") == "hello world"
+
+    def test_url_decode(self):
+        assert _clean_sentence("caf%C3%A9") == "caf\u00e9"
+
+    def test_html_tags_stripped(self):
+        assert _clean_sentence("<b>bold</b> text") == "bold text"
+
+    def test_html_entities_converted(self):
+        assert _clean_sentence("a &amp; b") == "a & b"
+
+    def test_no_percent_skips_unquote(self):
+        # Sentences without % should pass through unquote unchanged
+        assert _clean_sentence("normal sentence") == "normal sentence"
+
+    def test_no_ampersand_skips_unescape(self):
+        assert _clean_sentence("no entities here") == "no entities here"
+
+
+class TestParseTsv:
+    """Tests for Corpora._parse_tsv."""
+
+    def test_parse_basic(self, tmp_tsv, make_args):
+        rows = [
+            make_row(sentence="hello world", up_votes=2, down_votes=0),
+            make_row(client_id="c2", sentence="goodbye", up_votes=1, down_votes=1),
+        ]
+        path = tmp_tsv(rows)
+        args = make_args(path)
+        corpora = Corpora(args)
+        df = corpora._parse_tsv()
+        assert len(df) == 2
+        assert df.schema["up_votes"] == pl.Int32
+        assert df.schema["down_votes"] == pl.Int32
+
+    def test_parse_columns(self, tmp_tsv, make_args):
+        rows = [make_row()]
+        path = tmp_tsv(rows)
+        args = make_args(path)
+        corpora = Corpora(args)
+        df = corpora._parse_tsv()
+        expected_cols = {
+            "client_id", "path", "sentence_id", "sentence", "sentence_domain",
+            "up_votes", "down_votes", "age", "gender", "accents", "variant",
+            "locale", "segment",
+        }
+        assert set(df.columns) == expected_cols
+
+
+class TestPreprocessCommon:
+    """Tests for Corpora._preprocess_common."""
+
+    def _preprocess(self, tmp_tsv, make_args, rows):
+        path = tmp_tsv(rows)
+        args = make_args(path)
+        corpora = Corpora(args)
+        df = corpora._parse_tsv()
+        return corpora._preprocess_common(df)
+
+    def test_digit_sentence_invalidated(self, tmp_tsv, make_args):
+        rows = [make_row(sentence="has 123 digits", up_votes=5, down_votes=0)]
+        df = self._preprocess(tmp_tsv, make_args, rows)
+        assert df["up_votes"][0] == 0
+        assert df["down_votes"][0] == 2
+
+    def test_empty_sentence_invalidated(self, tmp_tsv, make_args):
+        rows = [make_row(sentence="   ", up_votes=5, down_votes=0)]
+        df = self._preprocess(tmp_tsv, make_args, rows)
+        assert df["up_votes"][0] == 0
+        assert df["down_votes"][0] == 2
+
+    def test_valid_sentence_unchanged(self, tmp_tsv, make_args):
+        rows = [make_row(sentence="good sentence", up_votes=3, down_votes=1)]
+        df = self._preprocess(tmp_tsv, make_args, rows)
+        assert df["sentence"][0] == "good sentence"
+        assert df["up_votes"][0] == 3
+        assert df["down_votes"][0] == 1
+
+    def test_whitespace_normalized(self, tmp_tsv, make_args):
+        rows = [make_row(sentence="  lots   of   space  ")]
+        df = self._preprocess(tmp_tsv, make_args, rows)
+        assert df["sentence"][0] == "lots of space"
+
+    def test_html_stripped(self, tmp_tsv, make_args):
+        rows = [make_row(sentence="<p>paragraph</p>")]
+        df = self._preprocess(tmp_tsv, make_args, rows)
+        assert df["sentence"][0] == "paragraph"
+
+    def test_control_chars_stripped(self, tmp_tsv, make_args):
+        rows = [make_row(sentence="hello\x00world")]
+        df = self._preprocess(tmp_tsv, make_args, rows)
+        assert df["sentence"][0] == "helloworld"
+
+
+class TestCorporaCreateAndSave:
+    """Integration tests for Corpora.create + save."""
+
+    def test_single_locale_end_to_end(self, tmp_tsv, make_args, tmp_path):
+        rows = [
+            make_row(client_id="c1", sentence="first sentence", up_votes=3, down_votes=0, locale="en"),
+            make_row(client_id="c2", sentence="second sentence", up_votes=3, down_votes=0, locale="en"),
+            make_row(client_id="c3", sentence="third sentence", up_votes=0, down_votes=3, locale="en"),
+        ]
+        path = tmp_tsv(rows)
+        args = make_args(path, langs=["en"])
+        corpora = Corpora(args)
+        corpora.create()
+        corpora.save(args.directory)
+
+        out_dir = tmp_path / "output" / "en"
+        assert out_dir.exists()
+        for name in ["other", "invalidated", "validated", "train", "dev", "test"]:
+            assert (out_dir / f"{name}.tsv").exists()
+
+    def test_invalid_locale_raises(self, tmp_tsv, make_args):
+        rows = [make_row(locale="en")]
+        path = tmp_tsv(rows)
+        args = make_args(path, langs=["xx"])
+        corpora = Corpora(args)
+        with pytest.raises(Exception, match="do not exist"):
+            corpora.create()

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1,8 +1,263 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+"""Tests for corporacreator.corpus (v1.5 Polars rewrite)."""
 
+import types
+
+import polars as pl
 import pytest
 
-__license__ = "mpl"
-__author__ = "kdavis-mozilla"
-__copyright__ = "kdavis-mozilla"
+from corporacreator import Corpus
+
+
+def _make_corpus(rows_data, locale="en", duplicate_sentence_count=1):
+    """Helper: build a Corpus from a list of (client_id, sentence, up, down) tuples."""
+    full_rows = []
+    for i, (cid, sentence, up, down) in enumerate(rows_data):
+        full_rows.append({
+            "client_id": cid,
+            "path": f"{cid}/audio_{i}.mp3",
+            "sentence_id": f"s{i}",
+            "sentence": sentence,
+            "sentence_domain": "",
+            "up_votes": up,
+            "down_votes": down,
+            "age": "",
+            "gender": "",
+            "accents": "",
+            "variant": "",
+            "locale": locale,
+            "segment": "",
+        })
+    df = pl.DataFrame(full_rows, schema={
+        "client_id": pl.String,
+        "path": pl.String,
+        "sentence_id": pl.String,
+        "sentence": pl.String,
+        "sentence_domain": pl.String,
+        "up_votes": pl.Int32,
+        "down_votes": pl.Int32,
+        "age": pl.String,
+        "gender": pl.String,
+        "accents": pl.String,
+        "variant": pl.String,
+        "locale": pl.String,
+        "segment": pl.String,
+    })
+    args = types.SimpleNamespace(
+        duplicate_sentence_count=duplicate_sentence_count,
+    )
+    return Corpus(args, locale, df)
+
+
+class TestPartition:
+    """Tests for Corpus._partition."""
+
+    def test_validated(self):
+        corpus = _make_corpus([
+            ("c1", "good", 3, 1),  # up > down, sum > 1 -> validated
+        ])
+        corpus._partition()
+        assert len(corpus.validated) == 1
+        assert len(corpus.other) == 0
+        assert len(corpus.invalidated) == 0
+
+    def test_invalidated(self):
+        corpus = _make_corpus([
+            ("c1", "bad", 1, 3),  # down > up, sum > 1 -> invalidated
+        ])
+        corpus._partition()
+        assert len(corpus.invalidated) == 1
+        assert len(corpus.validated) == 0
+
+    def test_other_low_votes(self):
+        corpus = _make_corpus([
+            ("c1", "dunno", 1, 0),  # sum <= 1 -> other
+        ])
+        corpus._partition()
+        assert len(corpus.other) == 1
+        assert len(corpus.validated) == 0
+
+    def test_other_tied_at_one(self):
+        corpus = _make_corpus([
+            ("c1", "tied", 1, 1),  # up==1, down==1 -> other
+        ])
+        corpus._partition()
+        assert len(corpus.other) == 1
+        assert len(corpus.validated) == 0
+        assert len(corpus.invalidated) == 0
+
+    def test_invalidated_tied_high(self):
+        corpus = _make_corpus([
+            ("c1", "tied high", 2, 2),  # up==down, sum > 2 -> invalidated
+        ])
+        corpus._partition()
+        assert len(corpus.invalidated) == 1
+
+    def test_mixed(self):
+        corpus = _make_corpus([
+            ("c1", "good", 3, 0),      # validated
+            ("c2", "bad", 0, 3),        # invalidated
+            ("c3", "unknown", 0, 0),    # other
+            ("c4", "tied", 1, 1),       # other
+            ("c5", "also bad", 2, 2),   # invalidated (tied, sum > 2)
+        ])
+        corpus._partition()
+        assert len(corpus.validated) == 1
+        assert len(corpus.invalidated) == 2
+        assert len(corpus.other) == 2
+
+
+class TestPreprocessLocale:
+    """Tests for Corpus._preprocess_locale."""
+
+    def test_no_preprocessor_skips(self):
+        corpus = _make_corpus([
+            ("c1", "sentence", 3, 0),
+        ], locale="ps")
+        original = corpus.corpus_data["sentence"][0]
+        corpus._preprocess_locale()
+        assert corpus.corpus_data["sentence"][0] == original
+
+    def test_cy_preprocessor_applied(self):
+        corpus = _make_corpus([
+            ("c1", "mae'n siwr iawn", 3, 0),
+        ], locale="cy")
+        corpus._preprocess_locale()
+        # cy preprocessor replaces ' with '
+        assert "\u2019" not in corpus.corpus_data["sentence"][0]
+        assert "'" in corpus.corpus_data["sentence"][0]
+
+    def test_preprocessor_invalidates_empty(self):
+        """If preprocessor returns empty string, votes should be invalidated."""
+        corpus = _make_corpus([
+            ("c1", "valid text", 3, 0),
+        ], locale="ky")
+        # ky removes bullet, so "•" alone becomes empty
+        corpus.corpus_data = corpus.corpus_data.with_columns(
+            pl.lit("\u2022").alias("sentence")  # bullet only
+        )
+        corpus._preprocess_locale()
+        assert corpus.corpus_data["up_votes"][0] == 0
+        assert corpus.corpus_data["down_votes"][0] == 2
+
+
+class TestCalculateSplitSizes:
+    """Tests for Corpus._calculate_split_sizes (binary search)."""
+
+    def test_zero_total(self):
+        corpus = _make_corpus([])
+        assert corpus._calculate_split_sizes(0) == (0, 0, 0)
+
+    def test_small_total(self):
+        corpus = _make_corpus([])
+        train, dev, test = corpus._calculate_split_sizes(100)
+        assert train + dev + test <= 100
+        assert dev == test  # both are sample_size(train)
+
+    def test_large_total(self):
+        corpus = _make_corpus([])
+        train, dev, test = corpus._calculate_split_sizes(5_000_000)
+        assert train + dev + test <= 5_000_000
+        assert dev == test
+        # For large N, sample_size converges to ~16641
+        assert 16000 <= dev <= 17000
+
+    def test_matches_v1_brute_force(self):
+        """Binary search result should match v1's linear scan for known values."""
+        from corporacreator import sample_size
+
+        corpus = _make_corpus([])
+
+        for total in [10, 100, 1000, 50000, 100000]:
+            train_v2, dev_v2, test_v2 = corpus._calculate_split_sizes(total)
+
+            # Replicate v1 linear scan
+            train_v1 = total
+            for t in range(total, 0, -1):
+                if 2 * int(sample_size(t)) + t <= total:
+                    train_v1 = t
+                    break
+            dev_v1 = int(sample_size(train_v1))
+
+            assert train_v2 == train_v1, f"Mismatch at total={total}"
+            assert dev_v2 == dev_v1, f"Mismatch at total={total}"
+
+
+class TestPostProcessValidated:
+    """Tests for dedup + speaker split logic."""
+
+    def test_split_produces_three_sets(self):
+        # 20 clips from 5 speakers, all validated
+        rows = []
+        for speaker_idx in range(5):
+            for clip_idx in range(4):
+                rows.append((
+                    f"speaker_{speaker_idx}",
+                    f"sentence {speaker_idx}_{clip_idx}",
+                    3, 0,
+                ))
+        corpus = _make_corpus(rows, duplicate_sentence_count=5)
+        corpus._partition()
+        del corpus.corpus_data
+        corpus._post_process_validated()
+        total = len(corpus.train) + len(corpus.dev) + len(corpus.test)
+        assert total <= len(corpus.validated)
+
+    def test_dedup_limits_sentences(self):
+        # Same sentence from 5 speakers, duplicate_sentence_count=2
+        rows = [
+            (f"speaker_{i}", "same sentence", 3, 0)
+            for i in range(5)
+        ]
+        corpus = _make_corpus(rows, duplicate_sentence_count=2)
+        corpus._partition()
+        del corpus.corpus_data
+        corpus._post_process_validated()
+        # train+dev+test should have at most 2 rows (dedup limit)
+        total = len(corpus.train) + len(corpus.dev) + len(corpus.test)
+        assert total <= 2
+
+    def test_empty_validated(self):
+        rows = [("c1", "bad", 0, 3)]  # invalidated, not validated
+        corpus = _make_corpus(rows)
+        corpus._partition()
+        del corpus.corpus_data
+        corpus._post_process_validated()
+        assert len(corpus.train) == 0
+        assert len(corpus.dev) == 0
+        assert len(corpus.test) == 0
+
+
+class TestSave:
+    """Tests for Corpus.save output format."""
+
+    def test_tsv_output_format(self, tmp_path):
+        rows = [
+            ("c1", "hello", 3, 0),
+            ("c2", "world", 3, 0),
+        ]
+        corpus = _make_corpus(rows)
+        corpus.create()
+        corpus.save(str(tmp_path))
+
+        out_dir = tmp_path / "en"
+        assert out_dir.exists()
+
+        # Check validated.tsv exists and is tab-separated
+        validated_path = out_dir / "validated.tsv"
+        assert validated_path.exists()
+        content = validated_path.read_text(encoding="utf-8")
+        lines = content.strip().split("\n")
+        assert len(lines) >= 1  # at least header
+        # Header should be tab-separated column names
+        header_cols = lines[0].split("\t")
+        assert "client_id" in header_cols
+        assert "sentence" in header_cols
+
+    def test_all_six_files_created(self, tmp_path):
+        rows = [("c1", "hello", 3, 0)]
+        corpus = _make_corpus(rows)
+        corpus.create()
+        corpus.save(str(tmp_path))
+        out_dir = tmp_path / "en"
+        for name in ["other", "invalidated", "validated", "train", "dev", "test"]:
+            assert (out_dir / f"{name}.tsv").exists()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,8 +1,29 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+"""Tests for corporacreator.logging (unchanged from v1)."""
 
-import pytest
+import logging
 
-__license__ = "mpl"
-__author__ = "kdavis-mozilla"
-__copyright__ = "kdavis-mozilla"
+from corporacreator import setup_logging
+
+
+class TestSetupLogging:
+    def test_does_not_raise(self):
+        """setup_logging should not raise for valid log levels."""
+        setup_logging(logging.INFO)
+        setup_logging(logging.DEBUG)
+
+    def test_format_contains_cc_py_tag(self):
+        """Log format should contain the CC-PY tag for bundler integration."""
+        # Remove existing handlers so basicConfig can install a fresh one
+        root = logging.getLogger()
+        original_handlers = root.handlers[:]
+        root.handlers.clear()
+        try:
+            setup_logging(logging.INFO)
+            assert any(
+                "CC-PY" in getattr(h, "formatter", None)._fmt
+                for h in root.handlers
+                if hasattr(getattr(h, "formatter", None), "_fmt")
+            )
+        finally:
+            # Restore original handlers for pytest
+            root.handlers = original_handlers

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,8 +1,29 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+"""Tests for corporacreator.tool (end-to-end integration)."""
 
-import pytest
+import os
 
-__license__ = "mpl"
-__author__ = "kdavis-mozilla"
-__copyright__ = "kdavis-mozilla"
+from conftest import make_row
+
+
+class TestEndToEnd:
+    """End-to-end test via tool.main."""
+
+    def test_full_pipeline(self, tmp_tsv, tmp_path):
+        from corporacreator.tool import main
+
+        rows = [
+            make_row(client_id="c1", sentence="hello world", up_votes=3, down_votes=0, locale="en"),
+            make_row(client_id="c2", sentence="goodbye world", up_votes=3, down_votes=0, locale="en"),
+            make_row(client_id="c3", sentence="bad clip", up_votes=0, down_votes=3, locale="en"),
+            make_row(client_id="c4", sentence="unknown", up_votes=0, down_votes=0, locale="en"),
+        ]
+        tsv_path = tmp_tsv(rows)
+        out_dir = str(tmp_path / "e2e_output")
+
+        main(["-f", tsv_path, "-d", out_dir, "-l", "en", "-v"])
+
+        en_dir = os.path.join(out_dir, "en")
+        assert os.path.exists(en_dir)
+        for name in ["other", "invalidated", "validated", "train", "dev", "test"]:
+            fpath = os.path.join(en_dir, name + ".tsv")
+            assert os.path.exists(fpath), f"Missing {name}.tsv"


### PR DESCRIPTION
- **Polars rewrite** -- replaced ``pandas`` + ``swifter`` with ``polars>=1.0``
- Drop-in replacement: CLI interface, TSV output, and split algorithm unchanged
- Vectorized common preprocessing pipeline
  (URL decode, HTML strip, unicode category filter, whitespace normalization)
- Binary search for train/dev/test split sizes -- O(log N) vs O(N)
- Speaker-based split via O(n) join instead of O(n²) per-speaker filtering
- Fixed multi-locale processing bug (``del df`` inside loop)
- Fixed test-split safety cap (was ``train_size``, now correctly ``test_size``)
- Added Polars DataFrames based test suite
